### PR TITLE
[HOPSWORKS-3233] Timestamp incompatibility Spark/Hive/Hudi - Hive fix

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/common/kvstore/pom.xml
+++ b/common/kvstore/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/common/network-common/pom.xml
+++ b/common/network-common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/common/network-shuffle/pom.xml
+++ b/common/network-shuffle/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/common/network-yarn/pom.xml
+++ b/common/network-yarn/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/common/sketch/pom.xml
+++ b/common/sketch/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/common/tags/pom.xml
+++ b/common/tags/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/common/unsafe/pom.xml
+++ b/common/unsafe/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/external/avro/pom.xml
+++ b/external/avro/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/external/docker-integration-tests/pom.xml
+++ b/external/docker-integration-tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/external/kafka-0-10-assembly/pom.xml
+++ b/external/kafka-0-10-assembly/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/external/kafka-0-10-sql/pom.xml
+++ b/external/kafka-0-10-sql/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/external/kafka-0-10-token-provider/pom.xml
+++ b/external/kafka-0-10-token-provider/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/external/kafka-0-10/pom.xml
+++ b/external/kafka-0-10/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/external/kinesis-asl-assembly/pom.xml
+++ b/external/kinesis-asl-assembly/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/external/kinesis-asl/pom.xml
+++ b/external/kinesis-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/external/spark-ganglia-lgpl/pom.xml
+++ b/external/spark-ganglia-lgpl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/graphx/pom.xml
+++ b/graphx/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hadoop-cloud/pom.xml
+++ b/hadoop-cloud/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/launcher/pom.xml
+++ b/launcher/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/mllib-local/pom.xml
+++ b/mllib-local/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/mllib/pom.xml
+++ b/mllib/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   </parent>
   <groupId>org.apache.spark</groupId>
   <artifactId>spark-parent_2.12</artifactId>
-  <version>3.1.1.2</version>
+  <version>3.1.1.3</version>
   <packaging>pom</packaging>
   <name>Spark Project Parent POM</name>
   <url>http://spark.apache.org/</url>

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/resource-managers/kubernetes/core/pom.xml
+++ b/resource-managers/kubernetes/core/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/resource-managers/kubernetes/integration-tests/pom.xml
+++ b/resource-managers/kubernetes/integration-tests/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/resource-managers/mesos/pom.xml
+++ b/resource-managers/mesos/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/resource-managers/yarn/pom.xml
+++ b/resource-managers/yarn/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/sql/catalyst/pom.xml
+++ b/sql/catalyst/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -98,6 +98,10 @@
       <artifactId>hive-storage-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>${hive.group}</groupId>
+      <artifactId>hive-serde</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-column</artifactId>
     </dependency>

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -99,6 +99,10 @@
     </dependency>
     <dependency>
       <groupId>${hive.group}</groupId>
+      <artifactId>hive-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${hive.group}</groupId>
       <artifactId>hive-serde</artifactId>
     </dependency>
     <dependency>

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DaysWritable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DaysWritable.scala
@@ -18,9 +18,9 @@
 package org.apache.spark.sql.execution.datasources
 
 import java.io.{DataInput, DataOutput, IOException}
+import java.sql.Date
 
-import org.apache.hadoop.hive.common.`type`.Date
-import org.apache.hadoop.hive.serde2.io.DateWritableV2
+import org.apache.hadoop.hive.serde2.io.DateWritable
 import org.apache.hadoop.io.WritableUtils
 
 import org.apache.spark.sql.catalyst.util.RebaseDateTime.{rebaseGregorianToJulianDays, rebaseJulianToGregorianDays}
@@ -38,16 +38,16 @@ import org.apache.spark.sql.catalyst.util.RebaseDateTime.{rebaseGregorianToJulia
 class DaysWritable(
     var gregorianDays: Int,
     var julianDays: Int)
-  extends DateWritableV2 {
+  extends DateWritable {
 
   def this() = this(0, 0)
   def this(gregorianDays: Int) =
     this(gregorianDays, rebaseGregorianToJulianDays(gregorianDays))
-  def this(dateWritable: DateWritableV2) = {
+  def this(dateWritable: DateWritable) = {
     this(
       gregorianDays = dateWritable match {
         case daysWritable: DaysWritable => daysWritable.gregorianDays
-        case dateWritable: DateWritableV2 =>
+        case dateWritable: DateWritable =>
         rebaseJulianToGregorianDays(dateWritable.getDays)
       },
       julianDays = dateWritable.getDays)
@@ -55,7 +55,10 @@ class DaysWritable(
 
   override def getDays: Int = julianDays
   override def get: Date = {
-    Date.ofEpochMilli(DateWritableV2.daysToMillis(julianDays))
+    new Date(DateWritable.daysToMillis(julianDays))
+  }
+  override def get(doesTimeMatter: Boolean): Date = {
+    new Date(DateWritable.daysToMillis(julianDays, doesTimeMatter))
   }
 
   override def set(d: Int): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DaysWritable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DaysWritable.scala
@@ -18,8 +18,8 @@
 package org.apache.spark.sql.execution.datasources
 
 import java.io.{DataInput, DataOutput, IOException}
-import java.sql.Date
 
+import org.apache.hadoop.hive.common.`type`.Date
 import org.apache.hadoop.hive.serde2.io.DateWritableV2
 import org.apache.hadoop.io.WritableUtils
 
@@ -55,7 +55,7 @@ class DaysWritable(
 
   override def getDays: Int = julianDays
   override def get: Date = {
-    new Date(DateWritableV2.daysToMillis(julianDays))
+    Date.ofEpochMilli(DateWritableV2.daysToMillis(julianDays))
   }
 
   override def set(d: Int): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DaysWritable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DaysWritable.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.datasources
 import java.io.{DataInput, DataOutput, IOException}
 import java.sql.Date
 
-import org.apache.hadoop.hive.serde2.io.DateWritable
+import org.apache.hadoop.hive.serde2.io.DateWritableV2
 import org.apache.hadoop.io.WritableUtils
 
 import org.apache.spark.sql.catalyst.util.RebaseDateTime.{rebaseGregorianToJulianDays, rebaseJulianToGregorianDays}
@@ -38,16 +38,16 @@ import org.apache.spark.sql.catalyst.util.RebaseDateTime.{rebaseGregorianToJulia
 class DaysWritable(
     var gregorianDays: Int,
     var julianDays: Int)
-  extends DateWritable {
+  extends DateWritableV2 {
 
   def this() = this(0, 0)
   def this(gregorianDays: Int) =
     this(gregorianDays, rebaseGregorianToJulianDays(gregorianDays))
-  def this(dateWritable: DateWritable) = {
+  def this(dateWritable: DateWritableV2) = {
     this(
       gregorianDays = dateWritable match {
         case daysWritable: DaysWritable => daysWritable.gregorianDays
-        case dateWritable: DateWritable =>
+        case dateWritable: DateWritableV2 =>
         rebaseJulianToGregorianDays(dateWritable.getDays)
       },
       julianDays = dateWritable.getDays)
@@ -55,10 +55,7 @@ class DaysWritable(
 
   override def getDays: Int = julianDays
   override def get: Date = {
-    new Date(DateWritable.daysToMillis(julianDays))
-  }
-  override def get(doesTimeMatter: Boolean): Date = {
-    new Date(DateWritable.daysToMillis(julianDays, doesTimeMatter))
+    new Date(DateWritableV2.daysToMillis(julianDays))
   }
 
   override def set(d: Int): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DaysWritableV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DaysWritableV2.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import java.io.{DataInput, DataOutput, IOException}
+
+import org.apache.hadoop.hive.common.`type`.Date
+import org.apache.hadoop.hive.serde2.io.DateWritableV2
+import org.apache.hadoop.io.WritableUtils
+import org.apache.spark.sql.catalyst.util.RebaseDateTime.{rebaseGregorianToJulianDays, rebaseJulianToGregorianDays}
+
+
+/**
+ * The class accepts/returns days in Gregorian calendar and rebase them
+ * via conversion to local date in Julian calendar for dates before 1582-10-15
+ * in read/write for backward compatibility with Spark 2.4 and earlier versions.
+ *
+ * @param gregorianDays The number of days since the epoch 1970-01-01 in
+ *                      Gregorian calendar.
+ * @param julianDays The number of days since the epoch 1970-01-01 in
+ *                   Julian calendar.
+ */
+class DaysWritableV2(
+    var gregorianDays: Int,
+    var julianDays: Int)
+  extends DateWritableV2 {
+
+  def this() = this(0, 0)
+  def this(gregorianDays: Int) =
+    this(gregorianDays, rebaseGregorianToJulianDays(gregorianDays))
+  def this(dateWritable: DateWritableV2) = {
+    this(
+      gregorianDays = dateWritable match {
+        case daysWritable: DaysWritableV2 => daysWritable.gregorianDays
+        case dateWritable: DateWritableV2 =>
+        rebaseJulianToGregorianDays(dateWritable.getDays)
+      },
+      julianDays = dateWritable.getDays)
+  }
+
+  override def getDays: Int = julianDays
+  override def get: Date = {
+    Date.ofEpochMilli(DateWritableV2.daysToMillis(julianDays))
+  }
+
+  override def set(d: Int): Unit = {
+    gregorianDays = d
+    julianDays = rebaseGregorianToJulianDays(d)
+  }
+
+  @throws[IOException]
+  override def write(out: DataOutput): Unit = {
+    WritableUtils.writeVInt(out, julianDays)
+  }
+
+  @throws[IOException]
+  override def readFields(in: DataInput): Unit = {
+    julianDays = WritableUtils.readVInt(in)
+    gregorianDays = rebaseJulianToGregorianDays(julianDays)
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcShimUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcShimUtils.scala
@@ -21,7 +21,8 @@ import org.apache.hadoop.hive.common.`type`.HiveDecimal
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch
 import org.apache.hadoop.hive.ql.io.sarg.{SearchArgument => OrcSearchArgument}
 import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf.{Operator => OrcOperator}
-import org.apache.hadoop.hive.serde2.io.{DateWritableV2, HiveDecimalWritable}
+import org.apache.hadoop.hive.serde2.io.{DateWritable, HiveDecimalWritable}
+
 import org.apache.spark.sql.catalyst.expressions.SpecializedGetters
 import org.apache.spark.sql.execution.datasources.DaysWritable
 import org.apache.spark.sql.types.Decimal
@@ -37,7 +38,7 @@ private[sql] object OrcShimUtils {
   private[sql] type SearchArgument = OrcSearchArgument
 
   def getGregorianDays(value: Any): Int = {
-    new DaysWritable(value.asInstanceOf[DateWritableV2]).gregorianDays
+    new DaysWritable(value.asInstanceOf[DateWritable]).gregorianDays
   }
 
   def getDecimal(value: Any): Decimal = {
@@ -45,7 +46,7 @@ private[sql] object OrcShimUtils {
     Decimal(decimal.bigDecimalValue, decimal.precision(), decimal.scale())
   }
 
-  def getDateWritable(reuseObj: Boolean): (SpecializedGetters, Int) => DateWritableV2 = {
+  def getDateWritable(reuseObj: Boolean): (SpecializedGetters, Int) => DateWritable = {
     if (reuseObj) {
       val result = new DaysWritable()
       (getter, ordinal) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcShimUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcShimUtils.scala
@@ -21,8 +21,7 @@ import org.apache.hadoop.hive.common.`type`.HiveDecimal
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch
 import org.apache.hadoop.hive.ql.io.sarg.{SearchArgument => OrcSearchArgument}
 import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf.{Operator => OrcOperator}
-import org.apache.hadoop.hive.serde2.io.{DateWritable, HiveDecimalWritable}
-
+import org.apache.hadoop.hive.serde2.io.{DateWritableV2, HiveDecimalWritable}
 import org.apache.spark.sql.catalyst.expressions.SpecializedGetters
 import org.apache.spark.sql.execution.datasources.DaysWritable
 import org.apache.spark.sql.types.Decimal
@@ -38,7 +37,7 @@ private[sql] object OrcShimUtils {
   private[sql] type SearchArgument = OrcSearchArgument
 
   def getGregorianDays(value: Any): Int = {
-    new DaysWritable(value.asInstanceOf[DateWritable]).gregorianDays
+    new DaysWritable(value.asInstanceOf[DateWritableV2]).gregorianDays
   }
 
   def getDecimal(value: Any): Decimal = {
@@ -46,7 +45,7 @@ private[sql] object OrcShimUtils {
     Decimal(decimal.bigDecimalValue, decimal.precision(), decimal.scale())
   }
 
-  def getDateWritable(reuseObj: Boolean): (SpecializedGetters, Int) => DateWritable = {
+  def getDateWritable(reuseObj: Boolean): (SpecializedGetters, Int) => DateWritableV2 = {
     if (reuseObj) {
       val result = new DaysWritable()
       (getter, ordinal) =>

--- a/sql/hive-thriftserver/pom.xml
+++ b/sql/hive-thriftserver/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.util._
-import org.apache.spark.sql.execution.datasources.DaysWritable
+import org.apache.spark.sql.execution.datasources.DaysWritableV2
 import org.apache.spark.sql.types
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
@@ -617,7 +617,7 @@ private[hive] trait HiveInspectors {
         case x: DateObjectInspector if x.preferWritable() =>
           data: Any => {
             if (data != null) {
-              new DaysWritable(x.getPrimitiveWritableObject(data).getDays).gregorianDays
+              new DaysWritableV2(x.getPrimitiveWritableObject(data).getDays).gregorianDays
             } else {
               null
             }
@@ -1011,11 +1011,11 @@ private[hive] trait HiveInspectors {
       new hadoopIo.BytesWritable(value.asInstanceOf[Array[Byte]])
     }
 
-  private def getDateWritable(value: Any): DaysWritable =
+  private def getDateWritable(value: Any): DaysWritableV2 =
     if (value == null) {
       null
     } else {
-      new DaysWritable(value.asInstanceOf[Int])
+      new DaysWritableV2(value.asInstanceOf[Int])
     }
 
   private def getTimestampWritable(value: Any): hiveIo.TimestampWritableV2 =

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
@@ -91,7 +91,7 @@ import org.apache.spark.unsafe.types.UTF8String
  *       org.apache.hadoop.hive.serde2.io.ByteWritable
  *       org.apache.hadoop.io.BytesWritable
  *       org.apache.hadoop.hive.serde2.io.DateWritable
- *       org.apache.hadoop.hive.serde2.io.TimestampWritable
+ *       org.apache.hadoop.hive.serde2.io.TimestampWritableV2
  *       org.apache.hadoop.hive.serde2.io.HiveDecimalWritable
  * Complex Type
  *   List: Object[] / java.util.List
@@ -189,7 +189,7 @@ private[hive] trait HiveInspectors {
     case c: Class[_] if c == classOf[hiveIo.ByteWritable] => ByteType
     case c: Class[_] if c == classOf[hiveIo.ShortWritable] => ShortType
     case c: Class[_] if c == classOf[hiveIo.DateWritable] => DateType
-    case c: Class[_] if c == classOf[hiveIo.TimestampWritable] => TimestampType
+    case c: Class[_] if c == classOf[hiveIo.TimestampWritableV2] => TimestampType
     case c: Class[_] if c == classOf[hadoopIo.Text] => StringType
     case c: Class[_] if c == classOf[hadoopIo.IntWritable] => IntegerType
     case c: Class[_] if c == classOf[hadoopIo.LongWritable] => LongType
@@ -1020,11 +1020,11 @@ private[hive] trait HiveInspectors {
       new DaysWritable(value.asInstanceOf[Int])
     }
 
-  private def getTimestampWritable(value: Any): hiveIo.TimestampWritable =
+  private def getTimestampWritable(value: Any): hiveIo.TimestampWritableV2 =
     if (value == null) {
       null
     } else {
-      new hiveIo.TimestampWritable(DateTimeUtils.toJavaTimestamp(value.asInstanceOf[Long]))
+      new hiveIo.TimestampWritableV2(DateTimeUtils.toJavaTimestamp(value.asInstanceOf[Long]))
     }
 
   private def getDecimalWritable(value: Any): hiveIo.HiveDecimalWritable =

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
@@ -20,14 +20,12 @@ package org.apache.spark.sql.hive
 import java.lang.reflect.{ParameterizedType, Type, WildcardType}
 
 import scala.collection.JavaConverters._
-
 import org.apache.hadoop.{io => hadoopIo}
-import org.apache.hadoop.hive.common.`type`.{HiveChar, HiveDecimal, HiveVarchar}
+import org.apache.hadoop.hive.common.`type`.{HiveChar, HiveDecimal, HiveVarchar, Timestamp}
 import org.apache.hadoop.hive.serde2.{io => hiveIo}
 import org.apache.hadoop.hive.serde2.objectinspector.{StructField => HiveStructField, _}
 import org.apache.hadoop.hive.serde2.objectinspector.primitive._
 import org.apache.hadoop.hive.serde2.typeinfo.{DecimalTypeInfo, TypeInfoFactory}
-
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
@@ -40,145 +38,182 @@ import org.apache.spark.unsafe.types.UTF8String
 /**
  * 1. The Underlying data type in catalyst and in Hive
  * In catalyst:
- *  Primitive  =>
- *     UTF8String
- *     int / scala.Int
- *     boolean / scala.Boolean
- *     float / scala.Float
- *     double / scala.Double
- *     long / scala.Long
- *     short / scala.Short
- *     byte / scala.Byte
- *     [[org.apache.spark.sql.types.Decimal]]
- *     Array[Byte]
- *     java.sql.Date
- *     java.sql.Timestamp
- *  Complex Types =>
- *    Map: `MapData`
- *    List: `ArrayData`
- *    Struct: [[org.apache.spark.sql.catalyst.InternalRow]]
- *    Union: NOT SUPPORTED YET
- *  The Complex types plays as a container, which can hold arbitrary data types.
+ * Primitive  =>
+ * UTF8String
+ * int / scala.Int
+ * boolean / scala.Boolean
+ * float / scala.Float
+ * double / scala.Double
+ * long / scala.Long
+ * short / scala.Short
+ * byte / scala.Byte
+ * [[org.apache.spark.sql.types.Decimal]]
+ * Array[Byte]
+ * java.sql.Date
+ * java.sql.Timestamp
+ * Complex Types =>
+ * Map: `MapData`
+ * List: `ArrayData`
+ * Struct: [[org.apache.spark.sql.catalyst.InternalRow]]
+ * Union: NOT SUPPORTED YET
+ * The Complex types plays as a container, which can hold arbitrary data types.
  *
  * In Hive, the native data types are various, in UDF/UDAF/UDTF, and associated with
  * Object Inspectors, in Hive expression evaluation framework, the underlying data are
  * Primitive Type
- *   Java Boxed Primitives:
- *       org.apache.hadoop.hive.common.type.HiveVarchar
- *       org.apache.hadoop.hive.common.type.HiveChar
- *       java.lang.String
- *       java.lang.Integer
- *       java.lang.Boolean
- *       java.lang.Float
- *       java.lang.Double
- *       java.lang.Long
- *       java.lang.Short
- *       java.lang.Byte
- *       org.apache.hadoop.hive.common.`type`.HiveDecimal
- *       byte[]
- *       java.sql.Date
- *       java.sql.Timestamp
- *   Writables:
- *       org.apache.hadoop.hive.serde2.io.HiveVarcharWritable
- *       org.apache.hadoop.hive.serde2.io.HiveCharWritable
- *       org.apache.hadoop.io.Text
- *       org.apache.hadoop.io.IntWritable
- *       org.apache.hadoop.hive.serde2.io.DoubleWritable
- *       org.apache.hadoop.io.BooleanWritable
- *       org.apache.hadoop.io.LongWritable
- *       org.apache.hadoop.io.FloatWritable
- *       org.apache.hadoop.hive.serde2.io.ShortWritable
- *       org.apache.hadoop.hive.serde2.io.ByteWritable
- *       org.apache.hadoop.io.BytesWritable
- *       org.apache.hadoop.hive.serde2.io.DateWritable
- *       org.apache.hadoop.hive.serde2.io.TimestampWritableV2
- *       org.apache.hadoop.hive.serde2.io.HiveDecimalWritable
+ * Java Boxed Primitives:
+ * org.apache.hadoop.hive.common.type.HiveVarchar
+ * org.apache.hadoop.hive.common.type.HiveChar
+ * java.lang.String
+ * java.lang.Integer
+ * java.lang.Boolean
+ * java.lang.Float
+ * java.lang.Double
+ * java.lang.Long
+ * java.lang.Short
+ * java.lang.Byte
+ * org.apache.hadoop.hive.common.`type`.HiveDecimal
+ * byte[]
+ * java.sql.Date
+ * java.sql.Timestamp
+ * Writables:
+ * org.apache.hadoop.hive.serde2.io.HiveVarcharWritable
+ * org.apache.hadoop.hive.serde2.io.HiveCharWritable
+ * org.apache.hadoop.io.Text
+ * org.apache.hadoop.io.IntWritable
+ * org.apache.hadoop.hive.serde2.io.DoubleWritable
+ * org.apache.hadoop.io.BooleanWritable
+ * org.apache.hadoop.io.LongWritable
+ * org.apache.hadoop.io.FloatWritable
+ * org.apache.hadoop.hive.serde2.io.ShortWritable
+ * org.apache.hadoop.hive.serde2.io.ByteWritable
+ * org.apache.hadoop.io.BytesWritable
+ * org.apache.hadoop.hive.serde2.io.DateWritable
+ * org.apache.hadoop.hive.serde2.io.TimestampWritableV2
+ * org.apache.hadoop.hive.serde2.io.HiveDecimalWritable
  * Complex Type
- *   List: Object[] / java.util.List
- *   Map: java.util.Map
- *   Struct: Object[] / java.util.List / java POJO
- *   Union: class StandardUnion { byte tag; Object object }
+ * List: Object[] / java.util.List
+ * Map: java.util.Map
+ * Struct: Object[] / java.util.List / java POJO
+ * Union: class StandardUnion { byte tag; Object object }
  *
  * NOTICE: HiveVarchar/HiveChar is not supported by catalyst, it will be simply considered as
- *  String type.
+ * String type.
  *
  *
  * 2. Hive ObjectInspector is a group of flexible APIs to inspect value in different data
- *  representation, and developers can extend those API as needed, so technically,
- *  object inspector supports arbitrary data type in java.
+ * representation, and developers can extend those API as needed, so technically,
+ * object inspector supports arbitrary data type in java.
  *
  * Fortunately, only few built-in Hive Object Inspectors are used in generic udf/udaf/udtf
  * evaluation.
  * 1) Primitive Types (PrimitiveObjectInspector & its sub classes)
-  {{{
-   public interface PrimitiveObjectInspector {
-     // Java Primitives (java.lang.Integer, java.lang.String etc.)
-     Object getPrimitiveJavaObject(Object o);
-     // Writables (hadoop.io.IntWritable, hadoop.io.Text etc.)
-     Object getPrimitiveWritableObject(Object o);
-     // ObjectInspector only inspect the `writable` always return true, we need to check it
-     // before invoking the methods above.
-     boolean preferWritable();
-     ...
-   }
-  }}}
-
- * 2) Complex Types:
- *   ListObjectInspector: inspects java array or [[java.util.List]]
- *   MapObjectInspector: inspects [[java.util.Map]]
- *   Struct.StructObjectInspector: inspects java array, [[java.util.List]] and
- *                                 even a normal java object (POJO)
- *   UnionObjectInspector: (tag: Int, object data) (TODO: not supported by SparkSQL yet)
- *
- * 3) ConstantObjectInspector:
- * Constant object inspector can be either primitive type or Complex type, and it bundles a
- * constant value as its property, usually the value is created when the constant object inspector
- * constructed.
  * {{{
-   public interface ConstantObjectInspector extends ObjectInspector {
-      Object getWritableConstantValue();
-      ...
-    }
-  }}}
- * Hive provides 3 built-in constant object inspectors:
- * Primitive Object Inspectors:
- *     WritableConstantStringObjectInspector
- *     WritableConstantHiveVarcharObjectInspector
- *     WritableConstantHiveCharObjectInspector
- *     WritableConstantHiveDecimalObjectInspector
- *     WritableConstantTimestampObjectInspector
- *     WritableConstantIntObjectInspector
- *     WritableConstantDoubleObjectInspector
- *     WritableConstantBooleanObjectInspector
- *     WritableConstantLongObjectInspector
- *     WritableConstantFloatObjectInspector
- *     WritableConstantShortObjectInspector
- *     WritableConstantByteObjectInspector
- *     WritableConstantBinaryObjectInspector
- *     WritableConstantDateObjectInspector
- * Map Object Inspector:
- *     StandardConstantMapObjectInspector
- * List Object Inspector:
- *     StandardConstantListObjectInspector]]
- * Struct Object Inspector: Hive doesn't provide the built-in constant object inspector for Struct
- * Union Object Inspector: Hive doesn't provide the built-in constant object inspector for Union
- *
- *
- * 3. This trait facilitates:
- *    Data Unwrapping: Hive Data => Catalyst Data (unwrap)
- *    Data Wrapping: Catalyst Data => Hive Data (wrap)
- *    Binding the Object Inspector for Catalyst Data (toInspector)
- *    Retrieving the Catalyst Data Type from Object Inspector (inspectorToDataType)
- *
- *
- * 4. Future Improvement (TODO)
- *   This implementation is quite ugly and inefficient:
- *     a. Pattern matching in runtime
- *     b. Small objects creation in catalyst data => writable
- *     c. Unnecessary unwrap / wrap for nested UDF invoking:
- *       e.g. date_add(printf("%s-%s-%s", a,b,c), 3)
- *       We don't need to unwrap the data for printf and wrap it again and passes in data_add
+ *public interface PrimitiveObjectInspector {
  */
+/ Java Primitives (java.lang.Integer, java.lang.String etc.)
+* Object getPrimitiveJavaObject (Object o);
+*// Writables (hadoop.io.IntWritable, hadoop.io.Text etc.)
+* Object getPrimitiveWritableObject (Object o);
+*// ObjectInspector only inspect the `writable` always return true, we need to check it
+*// before invoking the methods above.
+* boolean preferWritable ();
+*...
+*
+}
+*
+}
+}
+}
+*
+* 2) Complex Types:
+* ListObjectInspector: inspects java array or[[java.util.List]]
+* MapObjectInspector: inspects[[java.util.Map]]
+* Struct.StructObjectInspector: inspects java array, [[java.util.List]] and
+* even a normal java object (POJO)
+* UnionObjectInspector: (tag: Int,
+
+object data
+
+) (TODO: not supported by SparkSQL yet)
+*
+* 3) ConstantObjectInspector:
+* Constant
+
+object inspector
+
+can be either primitive type or Complex type, and it bundles a
+* constant value as its property, usually the value is created when the constant
+
+object inspector
+
+* constructed.
+* { { {
+* public interface ConstantObjectInspector extends ObjectInspector {
+* Object getWritableConstantValue ();
+*...
+*
+}
+*
+}
+}
+}
+* Hive provides 3 built - in constant
+
+object inspectors
+
+:
+* Primitive Object Inspectors:
+* WritableConstantStringObjectInspector
+* WritableConstantHiveVarcharObjectInspector
+* WritableConstantHiveCharObjectInspector
+* WritableConstantHiveDecimalObjectInspector
+* WritableConstantTimestampObjectInspector
+* WritableConstantIntObjectInspector
+* WritableConstantDoubleObjectInspector
+* WritableConstantBooleanObjectInspector
+* WritableConstantLongObjectInspector
+* WritableConstantFloatObjectInspector
+* WritableConstantShortObjectInspector
+* WritableConstantByteObjectInspector
+* WritableConstantBinaryObjectInspector
+* WritableConstantDateObjectInspector
+* Map Object Inspector:
+* StandardConstantMapObjectInspector
+* List Object Inspector:
+* StandardConstantListObjectInspector]]
+* Struct Object Inspector: Hive doesn 't provide the built - in constant
+
+object inspector
+
+for Struct
+* Union Object Inspector: Hive doesn 't provide the built - in constant
+
+object inspector
+
+for Union
+*
+*
+* 3.This
+
+trait facilitates
+
+:
+* Data Unwrapping: Hive Data => Catalyst Data (unwrap)
+* Data Wrapping: Catalyst Data => Hive Data (wrap)
+* Binding the Object Inspector for Catalyst Data (toInspector)
+* Retrieving the Catalyst Data Type from Object Inspector (inspectorToDataType)
+*
+*
+* 4.Future Improvement (TODO)
+* This implementation is quite ugly and inefficient:
+* a.Pattern matching in runtime
+* b.Small objects creation in catalyst data => writable
+* c.Unnecessary unwrap / wrap for nested UDF invoking:
+* e.g.date_add (printf ("%s-%s-%s", a, b, c), 3)
+* We don 't need to unwrap the data for printf and wrap it again and passes in data_add
+*/
+
 private[hive] trait HiveInspectors {
 
   def javaTypeToDataType(clz: Type): DataType = clz match {
@@ -305,35 +340,35 @@ private[hive] trait HiveInspectors {
         withNullSafe(o => getByteWritable(o))
       case _: ByteObjectInspector =>
         withNullSafe(o => o.asInstanceOf[java.lang.Byte])
-        // To spark HiveVarchar and HiveChar are same as string
+      // To spark HiveVarchar and HiveChar are same as string
       case _: HiveVarcharObjectInspector if x.preferWritable() =>
         withNullSafe(o => getStringWritable(o))
       case _: HiveVarcharObjectInspector =>
         withNullSafe { o =>
-            val s = o.asInstanceOf[UTF8String].toString
-            new HiveVarchar(s, s.length)
+          val s = o.asInstanceOf[UTF8String].toString
+          new HiveVarchar(s, s.length)
         }
       case _: HiveCharObjectInspector if x.preferWritable() =>
         withNullSafe(o => getStringWritable(o))
       case _: HiveCharObjectInspector =>
         withNullSafe { o =>
-            val s = o.asInstanceOf[UTF8String].toString
-            new HiveChar(s, s.length)
-          }
+          val s = o.asInstanceOf[UTF8String].toString
+          new HiveChar(s, s.length)
+        }
       case _: JavaHiveDecimalObjectInspector =>
         withNullSafe(o =>
           HiveDecimal.create(o.asInstanceOf[Decimal].toJavaBigDecimal))
       case _: JavaDateObjectInspector =>
         withNullSafe(o =>
-            DateTimeUtils.toJavaDate(o.asInstanceOf[Int]))
+          DateTimeUtils.toJavaDate(o.asInstanceOf[Int]))
       case _: JavaTimestampObjectInspector =>
         withNullSafe(o =>
-            DateTimeUtils.toJavaTimestamp(o.asInstanceOf[Long]))
+          DateTimeUtils.toJavaTimestamp(o.asInstanceOf[Long]))
       case _: HiveDecimalObjectInspector if x.preferWritable() =>
         withNullSafe(o => getDecimalWritable(o.asInstanceOf[Decimal]))
       case _: HiveDecimalObjectInspector =>
         withNullSafe(o =>
-            HiveDecimal.create(o.asInstanceOf[Decimal].toJavaBigDecimal))
+          HiveDecimal.create(o.asInstanceOf[Decimal].toJavaBigDecimal))
       case _: BinaryObjectInspector if x.preferWritable() =>
         withNullSafe(o => getBinaryWritable(o))
       case _: BinaryObjectInspector =>
@@ -378,9 +413,9 @@ private[hive] trait HiveInspectors {
           case ((field, wrapper), i) =>
             val tpe = structType(i).dataType
             ssoi.setStructFieldData(
-            result,
-            field,
-            wrapper(row.get(i, tpe)).asInstanceOf[AnyRef])
+              result,
+              field,
+              wrapper(row.get(i, tpe)).asInstanceOf[AnyRef])
         }
         result
       }
@@ -395,8 +430,8 @@ private[hive] trait HiveInspectors {
         val result = new java.util.ArrayList[AnyRef](wrappers.size)
         soi.getAllStructFieldRefs.asScala.zip(wrappers).zipWithIndex.foreach {
           case ((field, wrapper), i) =>
-          val tpe = structType(i).dataType
-          result.add(wrapper(row.get(i, tpe)).asInstanceOf[AnyRef])
+            val tpe = structType(i).dataType
+            result.add(wrapper(row.get(i, tpe)).asInstanceOf[AnyRef])
         }
         result
       }
@@ -416,12 +451,12 @@ private[hive] trait HiveInspectors {
       val keyWrapper = wrapperFor(moi.getMapKeyObjectInspector, mt.keyType)
       val valueWrapper = wrapperFor(moi.getMapValueObjectInspector, mt.valueType)
       withNullSafe { o =>
-          val map = o.asInstanceOf[MapData]
-          val jmap = new java.util.HashMap[Any, Any](map.numElements())
-          map.foreach(mt.keyType, mt.valueType, (k, v) =>
-            jmap.put(keyWrapper(k), valueWrapper(v)))
-          jmap
-        }
+        val map = o.asInstanceOf[MapData]
+        val jmap = new java.util.HashMap[Any, Any](map.numElements())
+        map.foreach(mt.keyType, mt.valueType, (k, v) =>
+          jmap.put(keyWrapper(k), valueWrapper(v)))
+        jmap
+      }
 
     case _ =>
       identity[Any]
@@ -433,11 +468,11 @@ private[hive] trait HiveInspectors {
    *
    * Strictly follows the following order in unwrapping (constant OI has the higher priority):
    * Constant Null object inspector =>
-   *   return null
+   * return null
    * Constant object inspector =>
-   *   extract the value from constant object inspector
+   * extract the value from constant object inspector
    * If object inspector prefers writable =>
-   *   extract writable from `data` and then get the catalyst type from the writable
+   * extract writable from `data` and then get the catalyst type from the writable
    * Extract the java object directly from the object inspector
    *
    * NOTICE: the complex data type requires recursive unwrapping.
@@ -697,7 +732,7 @@ private[hive] trait HiveInspectors {
         }
         data: Any => {
           if (data != null) {
-            InternalRow.fromSeq(unwrappers.map(_(data)).toSeq)
+            InternalRow.fromSeq(unwrappers.map(_ (data)).toSeq)
           } else {
             null
           }
@@ -738,10 +773,10 @@ private[hive] trait HiveInspectors {
   }
 
   def wrap(
-      row: InternalRow,
-      wrappers: Array[(Any) => Any],
-      cache: Array[AnyRef],
-      dataTypes: Array[DataType]): Array[AnyRef] = {
+            row: InternalRow,
+            wrappers: Array[(Any) => Any],
+            cache: Array[AnyRef],
+            dataTypes: Array[DataType]): Array[AnyRef] = {
     var i = 0
     val length = wrappers.length
     while (i < length) {
@@ -752,10 +787,10 @@ private[hive] trait HiveInspectors {
   }
 
   def wrap(
-      row: Seq[Any],
-      wrappers: Array[(Any) => Any],
-      cache: Array[AnyRef],
-      dataTypes: Array[DataType]): Array[AnyRef] = {
+            row: Seq[Any],
+            wrappers: Array[(Any) => Any],
+            cache: Array[AnyRef],
+            dataTypes: Array[DataType]): Array[AnyRef] = {
     var i = 0
     val length = wrappers.length
     while (i < length) {
@@ -768,7 +803,7 @@ private[hive] trait HiveInspectors {
   /**
    * @param dataType Catalyst data type
    * @return Hive java object inspector (recursively), not the Writable ObjectInspector
-   * We can easily map to the Hive built-in object inspector according to the data type.
+   *         We can easily map to the Hive built-in object inspector according to the data type.
    */
   def toInspector(dataType: DataType): ObjectInspector = dataType match {
     case ArrayType(tpe, _) =>
@@ -792,8 +827,8 @@ private[hive] trait HiveInspectors {
     case DecimalType() => PrimitiveObjectInspectorFactory.javaHiveDecimalObjectInspector
     case StructType(fields) =>
       ObjectInspectorFactory.getStandardStructObjectInspector(
-        java.util.Arrays.asList(fields.map(f => f.name) : _*),
-        java.util.Arrays.asList(fields.map(f => toInspector(f.dataType)) : _*))
+        java.util.Arrays.asList(fields.map(f => f.name): _*),
+        java.util.Arrays.asList(fields.map(f => toInspector(f.dataType)): _*))
     case _: UserDefinedType[_] =>
       val sqlType = dataType.asInstanceOf[UserDefinedType[_]].sqlType
       toInspector(sqlType)
@@ -803,6 +838,7 @@ private[hive] trait HiveInspectors {
    * Map the catalyst expression to ObjectInspector, however,
    * if the expression is `Literal` or foldable, a constant writable object inspector returns;
    * Otherwise, we always get the object inspector according to its data type(in catalyst)
+   *
    * @param expr Catalyst expression to be mapped
    * @return Hive java objectinspector (recursively).
    */
@@ -1024,7 +1060,8 @@ private[hive] trait HiveInspectors {
     if (value == null) {
       null
     } else {
-      new hiveIo.TimestampWritableV2(DateTimeUtils.toJavaTimestamp(value.asInstanceOf[Long]))
+      val ts = DateTimeUtils.toJavaTimestamp(value.asInstanceOf[Long]);
+      new hiveIo.TimestampWritableV2(Timestamp.ofEpochMilli(ts.getTime));
     }
 
   private def getDecimalWritable(value: Any): hiveIo.HiveDecimalWritable =
@@ -1037,6 +1074,7 @@ private[hive] trait HiveInspectors {
     }
 
   implicit class typeInfoConversions(dt: DataType) {
+
     import org.apache.hadoop.hive.serde2.typeinfo._
     import TypeInfoFactory._
 
@@ -1072,4 +1110,5 @@ private[hive] trait HiveInspectors {
           s"${dt.catalogString} cannot be converted to Hive TypeInfo")
     }
   }
+
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
@@ -186,7 +186,7 @@ private[hive] trait HiveInspectors {
     case c: Class[_] if c == classOf[hiveIo.HiveDecimalWritable] => DecimalType.SYSTEM_DEFAULT
     case c: Class[_] if c == classOf[hiveIo.ByteWritable] => ByteType
     case c: Class[_] if c == classOf[hiveIo.ShortWritable] => ShortType
-    case c: Class[_] if c == classOf[hiveIo.DateWritable] => DateType
+    case c: Class[_] if c == classOf[hiveIo.DateWritableV2] => DateType
     case c: Class[_] if c == classOf[hiveIo.TimestampWritableV2] => TimestampType
     case c: Class[_] if c == classOf[hadoopIo.Text] => StringType
     case c: Class[_] if c == classOf[hadoopIo.IntWritable] => IntegerType

--- a/streaming/pom.xml
+++ b/streaming/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1.2</version>
+    <version>3.1.1.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
Fixes `java.lang.ClassCastException` (`TimestampWritable/DateWritable` vs `TimestampWritableV2/DateWritableV2`) when writing Feature Groups with plain Spark/Hive (without Hudi).

Bumped version to 3.1.1.3 (using `mvn clean versions:set  -DnewVersion=3.1.1.3 -Pbigtop-dist,yarn,hadoop-provided,hadoop-3.2,parquet-provided,hive,sparkr`)

Ran tests for `sql/hive` and `sql/core` packages (`build/mvn package -pl sql/hive,sql/core`)